### PR TITLE
Add "tarball" target to Makefile

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -16,4 +16,3 @@ build:
 tarball:
     files:
         - LICENSE
-        - NOTICE

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ build: $(PROMU)
 	@echo ">> building binaries"
 	@$(PROMU) build --prefix $(PREFIX)
 
+tarball: $(PROMU)
+	@echo ">> building release tarball"
+	@$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
+
 clean:
 	@echo ">> Cleaning up"
 	@find . -type f -name '*~' -exec rm -fv {} \;
@@ -42,4 +46,4 @@ $(GOPATH)/bin/gometalinter lint:
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 		$(GO) get -u github.com/alecthomas/gometalinter
 
-.PHONY: all format vet build test promu clean $(GOPATH)/bin/promu $(GOPATH)/bin/gometalinter lint
+.PHONY: all format vet build test promu tarball clean $(GOPATH)/bin/promu $(GOPATH)/bin/gometalinter lint


### PR DESCRIPTION
This target can be useful to build release tarballs. 

Output example:

```
# make tarball
>> building release tarball
 >   logstash_exporter-0.1.2.linux-amd64.tar.gz
```

Also I removed `NOTICE` file from list because it doesn't exists in repository.